### PR TITLE
[IMP] account_move_tax Prevents multicompany issue 

### DIFF
--- a/account_move_tax/models/account_move_tax.py
+++ b/account_move_tax/models/account_move_tax.py
@@ -16,7 +16,7 @@ class AccountMove(models.Model):
         _inherit = 'account.move'
 
         def action_post(self):
-            if self.move_type in ['out_invoice','out_refund','in_invoice','in_refund']:
+            if self.company_id.country_code == 'AR' and self.move_type in ['out_invoice','out_refund','in_invoice','in_refund']:
                 self.compute_taxes()
             return super(AccountMove, self).action_post()
 


### PR DESCRIPTION
When posting account move in a multicompany environment and you are not working in a company that is from argentina, this ends in an error. So the PR ensures to only fire up the code when the document is from an argentine company.